### PR TITLE
misc improvements to packer.py

### DIFF
--- a/packer.py
+++ b/packer.py
@@ -1,24 +1,55 @@
-#!/usr/bin/python
-# encode a shell script with base64 and produce a python script that will unpack itself
-# and exceute
+#!/usr/bin/env python
+
+# encode a shell script with base64 and produce a python script that
+# will unpack itself and exceute
+#
+# WARNING: this will not work correctly with "complicated" shell
+#          scripts due to the fact that os.system() utilizes
+#          /bin/sh. Make sure your scripts function using "sh" rather
+#          than "bash." Always test your stuff!
 
 import os
 import sys
 import base64
 
-if len(sys.argv) != 2:
-        print "usage: %s inputfile" % sys.argv[0]
+# Make sure at least the inputfile was supplied.
+if len(sys.argv) == 1:
+        print "usage: %s <inputfile> [<outfile>]" % sys.argv[0]
+        exit(os.EX_USAGE)
 
-filename = sys.argv[1]
+infile = sys.argv[1]
 
-with open(filename, "rb") as shell_file:
+# Set outfile appropriately.
+if len(sys.argv) > 2:
+        outfile = sys.argv[2]
+else:
+        outfile = infile + ".py"
+
+# Make sure outfile is writable.
+try:
+        output_file = open(outfile, "w")
+except IOError, err:
+        print "Unable to open file %s for writing: %s" % (outfile, err)
+        exit(os.EX_USAGE)
+
+# Read infile, encode it.
+with open(infile, "rb") as shell_file:
       encoded_string = base64.b64encode(shell_file.read())
 
-output_file = open(filename + ".py", "w")
-output_file.write("#!/usr/bin/python\n");
-output_file.write("import os,base64;os.system(base64.b64decode('")
-output_file.write(encoded_string)
-output_file.write("'))\n")
-output_file.close()
 
-os.system("chmod 755 %s.py" % filename)
+# Write encoded data to outfile.
+output_template = \
+"""#!/usr/bin/env python
+import os
+import base64
+os.system(base64.b64decode('{encoded_string}'))
+"""
+
+context = { "encoded_string" : encoded_string }
+
+output_file.write(output_template.format(**context))
+
+# Clean up and exit
+output_file.close()
+os.chmod(outfile, 0755)
+exit(os.EX_OK)


### PR DESCRIPTION
The original version did not handle errors at all. Added checks and handling to the following situations:
- If an input file was not specified, it would continue to execute rather than displaying usage and exiting.
- If the input file didn't exist, it would try to encode nothing anyway.
- If the output file was not writable, it would try to write to it anyway.

Also added the option to specify an output file:
./pypacker.py input output

If output isn't specified, it just appends ".py" to the end of input.

Finally, changed to a formatted template when writing the file. This should make it easier to modify in the future rather than dealing with escaping characters and a handful of write() calls